### PR TITLE
#3032708 make sure the title reflects the name from the PWA settings page

### DIFF
--- a/js/sw.js
+++ b/js/sw.js
@@ -11,8 +11,8 @@ self.addEventListener('push', function (event) {
     return;
   }
 
-  var sendNotification = function(payload, icon, url) {
-    var title = "Open Social";
+  var sendNotification = function(payload, icon, url, site_name) {
+    var title = site_name || "Open Social";
     icon = icon || '/sites/default/files/images/touch/open-social.png';
     payload = payload || 'You\'ve received a message!';
     return self.registration.showNotification(title, {
@@ -39,11 +39,11 @@ self.addEventListener('push', function (event) {
         }
         // The page is still open but unfocused, so focus the tab.
         else if (clientList.length > 0) {
-          return sendNotification(data.message, data.icon, data.url);
+          return sendNotification(data.message, data.icon, data.url, data.site_name);
         }
         // The page is closed, send a push to retain engagement.
         else {
-          return sendNotification(data.message, data.icon, data.url);
+          return sendNotification(data.message, data.icon, data.url, data.site_name);
         }
       })
     );

--- a/modules/activity_send_push/activity_send_push.module
+++ b/modules/activity_send_push/activity_send_push.module
@@ -52,14 +52,17 @@ function activity_send_push_activity_insert(ActivityInterface $activity) {
         return;
       }
 
+      $pwa_settings = \Drupal::config('social_pwa.settings');
+
       // Set fields for payload.
       $message_to_send = html_entity_decode($message_to_send);
       $fields = [
         'message' => strip_tags($message_to_send),
         'url' => $activity->getRelatedEntityUrl()->toString(),
+        'site_name' => $pwa_settings->get('name'),
       ];
 
-      $icon = \Drupal::config('social_pwa.settings')->get('icons.icon');
+      $icon = $pwa_settings->get('icons.icon');
       if (!empty($icon)) {
         // Get the file id and path.
         $fid = $icon[0];


### PR DESCRIPTION
We now grab the title from the PWA Settings page (the name, not short name which is used for pinning to home screen) 

You can easily test it by going to `/admin/config/system/pwa` adding the necessary information and sending a push notification. 