### PR TITLE
Issue #3035070: Warning: array_flip(): Can only flip STRING and INTEGER values!

### DIFF
--- a/src/Form/ManifestSettingsForm.php
+++ b/src/Form/ManifestSettingsForm.php
@@ -91,8 +91,6 @@ class ManifestSettingsForm extends ConfigFormBase {
     $config = $this->config('social_pwa.settings');
     // Get the specific icons. Needed to get the correct path of the file.
     $icon = \Drupal::config('social_pwa.settings')->get('icons.icon');
-    // Get the file id and path.
-    $fid = $icon ? [$icon[0]] : [];
 
     // Start form.
     $form['social_pwa_manifest_settings'] = [
@@ -132,7 +130,7 @@ class ManifestSettingsForm extends ConfigFormBase {
       '#type' => 'managed_file',
       '#title' => $this->t('General App Icon'),
       '#description' => $this->t('Provide a square (.png) image. This image serves as your icon when the user adds the website to their home screen. <i>Minimum dimensions are 512px by 512px.</i>'),
-      '#default_value' => $fid,
+      '#default_value' => $icon ?: [],
       '#required' => TRUE,
       '#upload_location' => file_default_scheme() . '://images/touch/',
       '#upload_validators' => [

--- a/src/Form/ManifestSettingsForm.php
+++ b/src/Form/ManifestSettingsForm.php
@@ -92,7 +92,7 @@ class ManifestSettingsForm extends ConfigFormBase {
     // Get the specific icons. Needed to get the correct path of the file.
     $icon = \Drupal::config('social_pwa.settings')->get('icons.icon');
     // Get the file id and path.
-    $fid = $icon[0];
+    $fid = $icon ? [$icon[0]] : [];
 
     // Start form.
     $form['social_pwa_manifest_settings'] = [
@@ -132,7 +132,7 @@ class ManifestSettingsForm extends ConfigFormBase {
       '#type' => 'managed_file',
       '#title' => $this->t('General App Icon'),
       '#description' => $this->t('Provide a square (.png) image. This image serves as your icon when the user adds the website to their home screen. <i>Minimum dimensions are 512px by 512px.</i>'),
-      '#default_value' => [$fid],
+      '#default_value' => $fid,
       '#required' => TRUE,
       '#upload_location' => file_default_scheme() . '://images/touch/',
       '#upload_validators' => [


### PR DESCRIPTION
## Problem
When I install module and open settings page then I see the following error:

> Warning: array_flip(): Can only flip STRING and INTEGER values! in Drupal\Core\Entity\EntityStorageBase->loadMultiple() (line 264 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).
> Drupal\Core\Entity\EntityStorageBase->loadMultiple(Array) (Line: 249)
> Drupal\Core\Entity\EntityStorageBase->load(NULL) (Line: 527)
> Drupal\Core\Entity\Entity::load(NULL) (Line: 144)
> Drupal\file\Element\ManagedFile::valueCallback(Array, , Object)
> call_user_func_array(Array, Array) (Line: 1273)
> Drupal\Core\Form\FormBuilder->handleInputElement('social_pwa_settings_form', Array, Object) (Line: 990)
> Drupal\Core\Form\FormBuilder->doBuildForm('social_pwa_settings_form', Array, Object) (Line: 1060)
> Drupal\Core\Form\FormBuilder->doBuildForm('social_pwa_settings_form', Array, Object) (Line: 1060)
> Drupal\Core\Form\FormBuilder->doBuildForm('social_pwa_settings_form', Array, Object) (Line: 561)
> Drupal\Core\Form\FormBuilder->processForm('social_pwa_settings_form', Array, Object) (Line: 318)
> Drupal\Core\Form\FormBuilder->buildForm('social_pwa_settings_form', Object) (Line: 93)
> Drupal\Core\Controller\FormController->getContentResult(Object, Object)
> call_user_func_array(Array, Array) (Line: 123)
> Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 582)
> Drupal\Core\Render\Renderer->executeInRenderContext(Object, Object) (Line: 124)
> Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext(Array, Array) (Line: 97)
> Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->Drupal\Core\EventSubscriber\{closure}() (Line: 151)
> Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object, 1) (Line: 68)
> Symfony\Component\HttpKernel\HttpKernel->handle(Object, 1, 1) (Line: 57)
> Drupal\Core\StackMiddleware\Session->handle(Object, 1, 1) (Line: 47)
> Drupal\Core\StackMiddleware\KernelPreHandle->handle(Object, 1, 1) (Line: 99)
> Drupal\page_cache\StackMiddleware\PageCache->pass(Object, 1, 1) (Line: 78)
> Drupal\page_cache\StackMiddleware\PageCache->handle(Object, 1, 1) (Line: 47)
> Drupal\Core\StackMiddleware\ReverseProxyMiddleware->handle(Object, 1, 1) (Line: 52)
> Drupal\Core\StackMiddleware\NegotiationMiddleware->handle(Object, 1, 1) (Line: 23)
> Stack\StackedHttpKernel->handle(Object, 1, 1) (Line: 693)
> Drupal\Core\DrupalKernel->handle(Object) (Line: 19)

## Solution
Set an empty array for a default value of the icon field when the icon was not set.

## Issue tracker
https://www.drupal.org/project/social_pwa/issues/3035070