### PR TITLE
Issue #3048802: activity_send_push_activity_insert fails if the subject of an activity has been deleted

### DIFF
--- a/modules/activity_send_push/activity_send_push.module
+++ b/modules/activity_send_push/activity_send_push.module
@@ -52,13 +52,22 @@ function activity_send_push_activity_insert(ActivityInterface $activity) {
         return;
       }
 
+      $url = $activity->getRelatedEntityUrl();
+      // If the related entity does not have a canonical URL then we don't have
+      // anywhere for the user to go to when they click the push notification so
+      // we shouldn't send a notification at all.
+      if (!($url instanceof Url)) {
+        \Drupal::logger('activity_send_push')->error("Tried to send push notification for mid: %mid but the target entity doesn't have a canonical url", ['%mid' => $activity->field_activity_message->target_id]);
+        return;
+      }
+
       $pwa_settings = \Drupal::config('social_pwa.settings');
 
       // Set fields for payload.
       $message_to_send = html_entity_decode($message_to_send);
       $fields = [
         'message' => strip_tags($message_to_send),
-        'url' => $activity->getRelatedEntityUrl()->toString(),
+        'url' => $url->toString(),
         'site_name' => $pwa_settings->get('name'),
       ];
 


### PR DESCRIPTION
<h2>Problem</h2>
When the target of an activity (for example a user) has been deleted when the activity is processed then <code>$activity->getRelatedEntityUrl()->toString()</code> can cause a fatal error because <code>getRelatedEntityUrl</code> returns an empty string <code>""</code> which does not have a <code>toString</code> method.

<h2>Solution</h2>
Check that we have an entity URL to point to and if we don't then just omit the push notification because there's nowhere for the user to go to.