### PR TITLE
Remove homepage caching from service worker

### DIFF
--- a/js/sw.js
+++ b/js/sw.js
@@ -71,8 +71,10 @@ self.addEventListener('notificationclick', function(event) {
 });
 
 self.addEventListener('fetch', function(event) {
-  // Cache this page so the homescreen install banner works.
-  if ('cache' in self) {
-    cache.put('/');
-  }
+  // This event listener exists as a requirement for the 
+  // "Add to Homepage" function to work.
+  // See: https://developers.google.com/web/fundamentals/app-install-banners
+  // At this point it's been intentionally left blank 
+  // because caching the homepage does not sufficiently
+  // differentiate between the AN and LU states.
 });


### PR DESCRIPTION
<h2>Problem</h2>
The homepage caching does not discriminate between the logged in and logged out state of a user. This causes users that see the AN homepage and subsequently login to be returned to the AN homepage. A cache clear is required in order to see the LU homepage.

<h2>Solution</h2>
To fix this the caching line is removed. The fetch event listener is retained as is explained in the comments.

<h2>How to test</h2>
I've not been able to test this because it needs to be deployed somewhere. However, the following steps caused the bug:
- Open our prototype app
- See the AN homepage
- Login
- Try to navigate back to the homepage
- Before the fix you see the AN homepage, after the fix you should see the LU homepage.