### PR TITLE
Issue #3132364 by frankgraave: fix dependency name in info.yml

### DIFF
--- a/social_pwa.info.yml
+++ b/social_pwa.info.yml
@@ -5,5 +5,5 @@ core: 8.x
 package: Social
 configure: social_pwa.settings
 dependencies:
-  - social:activity_send_push_notification
+  - activity_send_push_notification
   - social_pwa:activity_send_push


### PR DESCRIPTION
The dependency was wrong, so only use the module name as dependency now.